### PR TITLE
Ability to extend HArray and use in pipeline

### DIFF
--- a/src/HArray.php
+++ b/src/HArray.php
@@ -108,7 +108,7 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
     public function append($value)
     {
         $answer = new HaystackArrayAppend($this->toArray());
-        return new HArray($answer->append($value));
+        return new static($answer->append($value));
     }
 
     /**
@@ -123,7 +123,7 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
     public function insert($value, $key = null)
     {
         $answer = new HaystackArrayInsert($this);
-        return new HArray($answer->insert($value, $key));
+        return new static($answer->insert($value, $key));
     }
 
 
@@ -137,7 +137,7 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
     public function remove($value)
     {
         $answer = new HaystackArrayRemove($this);
-        return new HArray($answer->remove($value));
+        return new static($answer->remove($value));
     }
 
     /**
@@ -151,7 +151,7 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
     public function slice($start, $length = null)
     {
         $answer = new HaystackArraySlice($this);
-        return new HArray($answer->slice($start, $length));
+        return new static($answer->slice($start, $length));
     }
 
     /**
@@ -163,7 +163,7 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
     public function map(callable $func)
     {
         $answer = new HArrayMap($this);
-        return new HArray($answer->map($func));
+        return new static($answer->map($func));
     }
 
     /**
@@ -195,7 +195,7 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
     public function filter(callable $func = null, $flag = null)
     {
         $answer = new HArrayFilter($this);
-        return new HArray($answer->filter($func, $flag));
+        return new static($answer->filter($func, $flag));
     }
 
     /**

--- a/src/HString.php
+++ b/src/HString.php
@@ -118,7 +118,7 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
     public function append($value)
     {
         $answer = new HaystackStringAppend($this);
-        return new HString($answer->append($value));
+        return new static($answer->append($value));
     }
 
     /**
@@ -132,7 +132,7 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
     public function insert($value, $key = null)
     {
         $answer = new HaystackStringInsert($this);
-        return new HString($answer->insert($value, $key));
+        return new static($answer->insert($value, $key));
     }
 
     /**
@@ -145,7 +145,7 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
     public function remove($value)
     {
         $answer = new HaystackStringRemove($this);
-        return new HString($answer->remove($value));
+        return new static($answer->remove($value));
     }
 
     /**
@@ -159,7 +159,7 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
     public function slice($start, $length = null)
     {
         $answer = new HaystackStringSlice($this);
-        return new HString($answer->slice($start, $length));
+        return new static($answer->slice($start, $length));
     }
 
     /**
@@ -347,7 +347,7 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
     public function map(callable $func)
     {
         $answer = new HStringMap($this);
-        return new HString($answer->map($func));
+        return new static($answer->map($func));
     }
 
     /**
@@ -371,7 +371,7 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
     public function filter(callable $func = null, $flag = null)
     {
         $answer =  new HStringFilter($this);
-        return new HString($answer->filter($func, $flag));
+        return new static($answer->filter($func, $flag));
     }
 
     /**


### PR DESCRIPTION
Prior to this PR I had issues extending HArray in my project. For example:

```
use Haystack\HArray;

class CustomHArray extends HArray
{
    /**
     * Splits array into two HArray's based on boolean result of predicate
     * function given each array item. Preserves array keys.
     *
     * @param callable $pred
     * @return array(HArray $matches, HArray $noMatches)
     */
    public function splitWith(callable $pred)
    {
        $true = $false = [];

        foreach ($this->arr as $key => $element) {
            if ($pred($element)) {
                $true[$key] = $element;
            } else {
                $false[$key] = $element;
            }
        }

        return array(new static($true), new static($false));
    }
}
```

Then use in pipeline:

```
$data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
list ($match, $noMatch) = (new CustomHArray($data))
    ->filter(function ($i) {
        return $i < 20;
    })
    ->splitWith(function ($i) {
        return $i >= 8;
    });
```

The above code would fail with a fatal error: `PHP Fatal error:  Call to undefined method Haystack\HArray::splitWith() in` because HArray->filter() was returning `new HArray(...)` where the classname HArray is hardcoded, so it always used the Haystack library's own HArray instead of my CustomHArray.

Another solution might be to mark the HArray class as `final` to prevent extending it and require any userland code to use composition instead of inheritance.

I left my example custom implementation in the repository for now to show failing tests for the custom version. If this PR is acceptable I'll rebase to remove it.
