### PR TITLE
Add factory methods to simplify method chaining

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -6,8 +6,7 @@ You can start using Haystack right away, like so:
 ```php
 use Haystack\HArray;
 
-$myArray = new HArray();
-$myArray = $myArray->insert("orange", "o");
+$myArray = HArray::make()->insert("orange", "o");
 ```
 
 Or you can use Haystack later on, like so:
@@ -17,8 +16,7 @@ use Haystack\HArray;
 
 $existingArray = range(1, 10);
 ...
-$myArray = new HArray($existingArray);
-$myArray = $myArray->insert("orange", "o");
+$myArray = HArray::make($existingArray)->insert("orange", "o");
 ```
 
 ## Requirements
@@ -40,8 +38,8 @@ using map, reduce and filter with a fluent interface.
 ```php
 use Haystack\HArray;
 
-$array = new HArray([3, 5, 7, 9, 11]);
-$result = $array->map(function ($i) { return $i * $i; })    // Square [9, 25, 49, 81, 121]
+$result = HArray::make([3, 5, 7, 9, 11])
+  ->map(function ($i) { return $i * $i; })                  // Square [9, 25, 49, 81, 121]
   ->filter(function ($i) { return $i > 30; })               // Only large numbers [49, 81, 121]
   ->reduce(function ($carry, $i) { return $carry += $i; }); // Sum
 
@@ -237,8 +235,7 @@ $removeLowerCaseVowels = function ($letter) {
 $consonantWord = $myString->filter($removeLowerCaseVowels); // "I m th vry mdl f  mdrn mjr-gnrl"
 
 $vowel = function ($word) {
-    $vowels = new HString("aeiou");
-    return $vowels->contains($word[0]);
+    return HString::make("aeiou")->contains($word[0]);
 };
 
 $firstLetterVowelWords = $myArray->filter($vowel); // ["a" => "apple"]
@@ -361,8 +358,7 @@ $myArray->sum(); // int(55)
 ```php
 use Haystack\HArray;
 
-$myArray = new HArray(range(1, 4));
-$array = $myArray->toArray(); // [1, 2, 3, 4]
+$array = HArray::make(range(1, 4))->toArray(); // [1, 2, 3, 4]
 ```
 
 **toHString($glue = "")** - Converts an HArray to an HString. This is similar to PHP's [`implode`](http://php
@@ -376,8 +372,7 @@ $array = $myArray->toArray(); // [1, 2, 3, 4]
 use Haystack\HArray;
 use Haystack\HString;
 
-$myArray = new HArray(range(1, 4));
-$lawrenceWelk = $myArray->toHString(" and-a "); // HString("1 and-a 2 and-a 3 and-a 4")
+$lawrenceWelk = HArray::make(range(1, 4))->toHString(" and-a "); // HString("1 and-a 2 and-a 3 and-a 4")
 ```
 
 ## HString-only Methods
@@ -386,8 +381,7 @@ $lawrenceWelk = $myArray->toHString(" and-a "); // HString("1 and-a 2 and-a 3 an
 ```php
 use Haystack\HString;
 
-$myString = new HString("foo bar");
-$string = $myString->toString(); // "foo bar"
+$string = HString::make("foo bar")->toString(); // "foo bar"
 ```
 
 **toHArray($delim = " ", $limit = null)** - Converts an HString to an HArray. This is similar to PHP's [`explode`]

--- a/src/HArray.php
+++ b/src/HArray.php
@@ -52,6 +52,16 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
         }
     }
 
+    /**
+     * Factory method for simplifying method chaining.
+     * @param  array $arr Array to be operated on
+     * @return HArray     New instance of HArray
+     */
+    public static function make($arr = null)
+    {
+        return new static($arr);
+    }
+
     public function toArray()
     {
         return $this->arr;

--- a/src/HString.php
+++ b/src/HString.php
@@ -46,6 +46,16 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
     }
 
     /**
+     * Factory method for simplifying method chaining.
+     * @param  string $string String to be operated on
+     * @return HString        New instance of HString
+     */
+    public static function make($string = null)
+    {
+        return new static($string);
+    }
+
+    /**
      * @return string
      */
     public function __toString()

--- a/tests/HArrayTest.php
+++ b/tests/HArrayTest.php
@@ -27,6 +27,11 @@ class HArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($array);
     }
 
+    public function testMake()
+    {
+        $this->assertInstanceOf("Haystack\HArray", HArray::make(["apple"]));
+    }
+
     /**
      * @dataProvider goodArraysProvider
      *

--- a/tests/HStringTest.php
+++ b/tests/HStringTest.php
@@ -20,6 +20,11 @@ class HStringTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($emptyString);
     }
 
+    public function testMake()
+    {
+        $this->assertInstanceOf("Haystack\HString", HString::make("foobar"));
+    }
+
     /**
      * @dataProvider stringOfThingsProvider
      *


### PR DESCRIPTION
During John's presentation at Midwest PHP it occurred to me that having a factory method for creating instances of the Haystack classes would be helpful in simplifying the execution of the code. I think this is  also more expressive as John might say.

I am totally open to changing `make` to something else if you would prefer.

Also I updated a few places in the manual where I thought it made sense. If you think there are other places that should be updated, or if you feel the manual should be left as it was I can change that as well.

I am interested in your feedback.
