### PR TITLE
Allow objects in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.x.x](https://github.com/ericpoe/haystack/tree/v1.x.x) - 2016-03-xx
+
+### Changes
+* Bugfix: HArray::remove() no longer makes the entire array have numeric keys if the removed key was numeric
+* Potential BC Break: HArray can now contain objects. So `new HArray(new \DateTime())` is now possible!
+
+* **Manual**
+    * Some examples were changed to show an alternative manner of declaring the Haystack object for use in pipelining (thanks for the heads-up, ajmichels!)
+
 ## [1.0.2](https://github.com/ericpoe/haystack/tree/v1.0.2) - 2016-03-01
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Packagist Version](https://img.shields.io/packagist/v/ericpoe/haystack.svg?style=flat-square)](https://packagist.org/packages/ericpoe/haystack)
 
 # Haystack
-Forget Haystack vs Needle order, the object *IS* the Haystack.
+Forget Haystack vs Needle order, the object *IS* the Haystack. Haystack is a library that allows for pipelining and
+immutable structures.
 
 ## Install
 Haystack is installable as a [Composer](http://getcomposer.org) package:

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -6,8 +6,7 @@ You can start using Haystack right away, like so:
 ```php
 use Haystack\HArray;
 
-$myArray = new HArray();
-$myArray = $myArray->insert("orange", "o");
+$myArray = (new HArray())->insert("orange", "o");
 ```
 
 Or you can use Haystack later on, like so:
@@ -17,8 +16,7 @@ use Haystack\HArray;
 
 $existingArray = range(1, 10);
 ...
-$myArray = new HArray($existingArray);
-$myArray = $myArray->insert("orange", "o");
+$myArray = (new HArray($existingArray))->insert("orange", "o");
 ```
 
 ## Requirements
@@ -40,8 +38,8 @@ using map, reduce and filter with a fluent interface.
 ```php
 use Haystack\HArray;
 
-$array = new HArray([3, 5, 7, 9, 11]);
-$result = $array->map(function ($i) { return $i * $i; })    // Square [9, 25, 49, 81, 121]
+$result = (new HArray([3, 5, 7, 9, 11]))
+  ->map(function ($i) { return $i * $i; })                  // Square [9, 25, 49, 81, 121]
   ->filter(function ($i) { return $i > 30; })               // Only large numbers [49, 81, 121]
   ->reduce(function ($carry, $i) { return $carry += $i; }); // Sum
 
@@ -180,11 +178,9 @@ $rot13 = function ($letter) {
 
 $newString = $myString->map($rot13); // "V nz gur irel zbqry bs n zbqrea znwbe-trareny"
 
-$capitalize = function ($word) {
+$newArr = $myArray->map(function ($word) {
     return strtoupper($word);
-};
-
-$newArr = $myArray->map($capitalize); // ["a" => "APPLE", "b" => "BANANA", "c" => "CELERY"]
+}); // ["a" => "APPLE", "b" => "BANANA", "c" => "CELERY"]
 ```
 
 **walk($callable)** - Walk does an in-place update of items in the object.
@@ -230,15 +226,13 @@ $myString = new HString("I am the very model of a modern major-general");
 $myArray = new HArray(["a" => "apple", "b" => "banana", "c" => "celery"]);
 
 $removeLowerCaseVowels = function ($letter) {
-    $vowels = new HString("aeiou");
-    return !$vowels->contains($letter);
+    return false === (new HString("aeiou"))->contains($letter);
 };
 
 $consonantWord = $myString->filter($removeLowerCaseVowels); // "I m th vry mdl f  mdrn mjr-gnrl"
 
 $vowel = function ($word) {
-    $vowels = new HString("aeiou");
-    return $vowels->contains($word[0]);
+    return (new HString("aeiou"))->contains($word[0]);
 };
 
 $firstLetterVowelWords = $myArray->filter($vowel); // ["a" => "apple"]
@@ -335,11 +329,11 @@ $tailArray = $myArray->tail(); // ["b" => "banana", "c" => "celery"]
 use Haystack\HArray;
 use Haystack\HString;
 
-$myString = new HString("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
-$myArray = new HArray(range(1, 10));
+(new HString("1, 2, 3, 4, 5, 6, 7, 8, 9, 10"))
+    ->product(); // int(3628800)
 
-$myString->product(); // int(3628800)
-$myArray->product(); // int(3628800)
+(new HArray(range(1, 10)))
+    ->product(); // int(3628800)
 ```
 
 **sum()** - Calculates the sum of the values in the collection. Any non-number values are equal to 0.
@@ -348,11 +342,11 @@ $myArray->product(); // int(3628800)
 use Haystack\HArray;
 use Haystack\HString;
 
-$myString = new HString("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
-$myArray = new HArray(range(1, 10));
+(new HString("1, 2, 3, 4, 5, 6, 7, 8, 9, 10"))
+    ->sum(); // int(55)
 
-$myString->sum(); // int(55)
-$myArray->sum(); // int(55)
+(new HArray(range(1, 10)))
+    ->sum(); // int(55)
 ```
 
 ## HArray-only Methods
@@ -361,8 +355,7 @@ $myArray->sum(); // int(55)
 ```php
 use Haystack\HArray;
 
-$myArray = new HArray(range(1, 4));
-$array = $myArray->toArray(); // [1, 2, 3, 4]
+$array = (new HArray(range(1, 4)))->toArray(); // [1, 2, 3, 4]
 ```
 
 **toHString($glue = "")** - Converts an HArray to an HString. This is similar to PHP's [`implode`](http://php
@@ -376,8 +369,8 @@ $array = $myArray->toArray(); // [1, 2, 3, 4]
 use Haystack\HArray;
 use Haystack\HString;
 
-$myArray = new HArray(range(1, 4));
-$lawrenceWelk = $myArray->toHString(" and-a "); // HString("1 and-a 2 and-a 3 and-a 4")
+$lawrenceWelk = (new HArray(range(1, 4)))
+                    ->toHString(" and-a "); // HString("1 and-a 2 and-a 3 and-a 4")
 ```
 
 ## HString-only Methods
@@ -386,8 +379,7 @@ $lawrenceWelk = $myArray->toHString(" and-a "); // HString("1 and-a 2 and-a 3 an
 ```php
 use Haystack\HString;
 
-$myString = new HString("foo bar");
-$string = $myString->toString(); // "foo bar"
+$string = (new HString("foo bar"))->toString(); // "foo bar"
 ```
 
 **toHArray($delim = " ", $limit = null)** - Converts an HString to an HArray. This is similar to PHP's [`explode`]

--- a/src/Container/HaystackArrayAppend.php
+++ b/src/Container/HaystackArrayAppend.php
@@ -25,13 +25,9 @@ class HaystackArrayAppend
     {
         $value = $value instanceof HArray ? $value->toArray() : $value;
 
-        if (Helper::canBeInArray($value)) {
-            $this->arr->append($value);
+        $this->arr->append($value);
 
-            return $this->arr;
-        } else {
-            throw new \InvalidArgumentException(sprintf("%s cannot be appended to an HArray", Helper::getType($value)));
-        }
+        return $this->arr->getArrayCopy();
     }
 
 }

--- a/src/Container/HaystackArrayAppend.php
+++ b/src/Container/HaystackArrayAppend.php
@@ -1,7 +1,6 @@
 <?php
 namespace Haystack\Container;
 
-use Haystack\Helpers\Helper;
 use Haystack\HArray;
 
 class HaystackArrayAppend

--- a/src/Container/HaystackArrayContains.php
+++ b/src/Container/HaystackArrayContains.php
@@ -1,7 +1,6 @@
 <?php
 namespace Haystack\Container;
 
-use Haystack\Helpers\Helper;
 use Haystack\HArray;
 
 class HaystackArrayContains
@@ -22,12 +21,6 @@ class HaystackArrayContains
      */
     public function contains($value)
     {
-        if (Helper::canBeInArray($value)) {
-            $arr = $this->arr->toArray();
-            $answer = in_array($value, $arr);
-        } else {
-            throw new \InvalidArgumentException(sprintf("%s cannot be contained within an HArray", Helper::getType($value)));
-        }
-        return $answer;
+        return in_array($value, $this->arr->toArray());
     }
 }

--- a/src/Container/HaystackArrayInsert.php
+++ b/src/Container/HaystackArrayInsert.php
@@ -1,8 +1,8 @@
 <?php
 namespace Haystack\Container;
 
-use Haystack\Helpers\Helper;
 use Haystack\HArray;
+use Haystack\Helpers\Helper;
 use Haystack\HString;
 
 class HaystackArrayInsert
@@ -23,7 +23,7 @@ class HaystackArrayInsert
         } elseif (Helper::canBeInArray($value)) {
             $valueArray = $value;
         } else {
-            throw new \InvalidArgumentException(sprintf("%s cannot be contained within an HArray", Helper::getType($value)));
+            $valueArray = [$value];
         }
 
         if (isset($key)) {
@@ -55,7 +55,7 @@ class HaystackArrayInsert
         $array = $value;
         $length = (int) $key;
 
-        return array($array, $length);
+        return [$array, $length];
     }
 
     /**
@@ -68,7 +68,7 @@ class HaystackArrayInsert
         $array = [$key => $value];
         $length = sizeof($this->arr);
 
-        return array($array, $length);
+        return [$array, $length];
     }
 
     /**
@@ -80,6 +80,6 @@ class HaystackArrayInsert
         $array = $value;
         $length = sizeof($this->arr);
 
-        return array($array, $length);
+        return [$array, $length];
     }
 }

--- a/src/Container/HaystackArrayRemove.php
+++ b/src/Container/HaystackArrayRemove.php
@@ -1,7 +1,6 @@
 <?php
 namespace Haystack\Container;
 
-use Haystack\Helpers\Helper;
 use Haystack\HArray;
 
 class HaystackArrayRemove
@@ -15,26 +14,25 @@ class HaystackArrayRemove
 
     public function remove($value)
     {
-        if (Helper::canBeInArray($value)) {
-            if (false === $this->arr->contains($value)) {
-                return $this->arr;
-            }
-
-            $newArr = $this->arr->toArray();
-            $key = $this->arr->locate($value);
-        } else {
-            throw new \InvalidArgumentException(sprintf("%s cannot be contained within an HArray", Helper::getType($value)));
+        if (false === $this->arr->contains($value)) {
+            return $this->arr;
         }
 
-        if (is_numeric($key)) {
-            unset($newArr[$key]);
+        $newArr = $this->arr->toArray();
+        $key = $this->arr->locate($value);
+        unset($newArr[$key]);
 
+        if ($this->allKeysNumeric(array_keys($newArr))) {
             return array_values($newArr);
         }
 
-        // key is string
-        unset($newArr[$key]);
-
         return $newArr;
+    }
+
+    private function allKeysNumeric(array $keys)
+    {
+        return sizeof($keys) === sizeof(array_filter($keys, function ($key) {
+            return is_numeric($key);
+        }));
     }
 }

--- a/src/HArray.php
+++ b/src/HArray.php
@@ -14,7 +14,6 @@ use Haystack\Functional\HArrayFilter;
 use Haystack\Functional\HArrayMap;
 use Haystack\Functional\HArrayReduce;
 use Haystack\Functional\HArrayWalk;
-use Haystack\Helpers\Helper;
 use Haystack\Math\MathInterface;
 
 class HArray extends \ArrayObject implements ContainerInterface, FunctionalInterface, MathInterface

--- a/src/HArray.php
+++ b/src/HArray.php
@@ -22,28 +22,23 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
     const USE_KEY = "key";
     const USE_BOTH = "both";
 
-    /** @var array */
+    /** @var \ArrayObject */
     protected $arr;
 
-    public function __construct($arr = null)
+    public function __construct($arr = [])
     {
-        if (is_null($arr)) {
-            parent::__construct();
-            $this->arr = [];
-        } elseif (is_array($arr)) {
-            parent::__construct($arr);
-            $this->arr = $arr;
-        } elseif ($arr instanceof \ArrayObject) {
+        if ($arr instanceof \ArrayObject) {
             parent::__construct($arr);
             $this->arr = $arr->getArrayCopy();
         } elseif ($arr instanceof HString) {
             parent::__construct();
             $this->arr = [$arr->toString()];
-        } elseif (is_scalar($arr)) {
-            parent::__construct();
+        } elseif (is_scalar($arr) || 'object' === gettype($arr)) {
+            parent::__construct([$arr]);
             $this->arr = [$arr];
         } else {
-            throw new \ErrorException(sprintf("%s cannot be instantiated as an HArray", Helper::getType($arr)));
+            parent::__construct((array) $arr);
+            $this->arr = (array) $arr;
         }
     }
 

--- a/src/HArray.php
+++ b/src/HArray.php
@@ -120,7 +120,6 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
      *
      * @param $value
      * @return HArray
-     * @throws \InvalidArgumentException
      */
     public function remove($value)
     {

--- a/src/HArray.php
+++ b/src/HArray.php
@@ -68,7 +68,6 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
      *
      * @param $value
      * @return boolean
-     * @throws \InvalidArgumentException
      */
     public function contains($value)
     {

--- a/src/HArray.php
+++ b/src/HArray.php
@@ -93,7 +93,6 @@ class HArray extends \ArrayObject implements ContainerInterface, FunctionalInter
      *
      * @param $value
      * @return HArray
-     * @throws \InvalidArgumentException
      */
     public function append($value)
     {

--- a/src/HString.php
+++ b/src/HString.php
@@ -25,10 +25,10 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
     private $ptr; // pointer for iterating through $string
 
     /**
-     * @param null $string
+     * @param string $string
      * @throws \ErrorException
      */
-    public function __construct($string = null)
+    public function __construct($string = "")
     {
         if (is_scalar($string) || $string instanceof HString) {
             $this->string = (string) $string;

--- a/tests/Container/HArrayAppendTest.php
+++ b/tests/Container/HArrayAppendTest.php
@@ -37,36 +37,17 @@ class HArrayAppendTest extends \PHPUnit_Framework_TestCase
 
     public function appendProvider()
     {
+        $dateTime = new \DateTime();
+
         return [
             "String to list" => ["list", "ebble", new HArray(["apple", "bobble", "cobble", "dobble", "ebble"])],
             "String array to list" => ["list", ["ebble"], new HArray(["apple", "bobble", "cobble", "dobble", ["ebble"]])],
             "String HArray to list" => ["list", new HArray(["ebble"]), new HArray(["apple", "bobble", "cobble", "dobble", ["ebble"]])],
+            "Object to list" => ["list", $dateTime, new HArray(["apple", "bobble", "cobble", "dobble", $dateTime])],
             "String to dictionary" => ["dict", "ebble", new HArray(["a" => "apple", "b" => "bobble", "c" => "cobble", "d" => "dobble", "0" => "ebble"])],
             "String array to dictionary" => ["dict", ["e" => "ebble"], new HArray(["a" => "apple", "b" => "bobble", "c" => "cobble", "d" => "dobble", ["e" => "ebble"]])],
             "String HArray to dictionary" => ["dict", new HArray(["e" => "ebble"]), new HArray(["a" => "apple", "b" => "bobble", "c" => "cobble", "d" => "dobble", ["e" => "ebble"]])],
+            "Object to dictionary" => ["dict", $dateTime, new HArray(["a" => "apple", "b" => "bobble", "c" => "cobble", "d" => "dobble", 0 => $dateTime])],
         ];
     }
-
-    /**
-     * @dataProvider badAppendProvider
-     *
-     * @param $item
-     * @param $exceptionMsg
-     */
-    public function testAppendBadThingsToArray($item, $exceptionMsg)
-    {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
-
-        $this->arrList->append($item);
-    }
-
-    public function badAppendProvider()
-    {
-        return [
-            "DateTime" => [new \DateTime(), "DateTime cannot be appended to an HArray"],
-            "SPL Object" => [new \SplDoublyLinkedList(), "SplDoublyLinkedList cannot be appended to an HArray"],
-        ];
-    }
-
 }

--- a/tests/Container/HArrayContainsTest.php
+++ b/tests/Container/HArrayContainsTest.php
@@ -47,25 +47,11 @@ class HArrayContainsTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    /**
-     * @dataProvider badArrayContainsProvider
-     *
-     * @param $item
-     * @param $exceptionMsg
-     */
-    public function testBadArrayContains($item, $exceptionMsg)
+    public function testContainsObjectTypeInHArray()
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $list = $this->arrList->append(new \SplDoublyLinkedList());
 
-        $this->arrList->contains($item);
-    }
-
-    public function badArrayContainsProvider()
-    {
-        return [
-            "DateTime" => [new \DateTime(), "DateTime cannot be contained within an HArray"],
-            "SPL Object" => [new \SplDoublyLinkedList(), "SplDoublyLinkedList cannot be contained within an HArray"],
-        ];
+        $this->assertTrue($list->contains(new \SplDoublyLinkedList()), "SplDoublyLinkedList should be in the list");
+        $this->assertFalse($list->contains(new \DateTime()), "DateTime should be in the list");
     }
 }

--- a/tests/Container/HArrayInsertTest.php
+++ b/tests/Container/HArrayInsertTest.php
@@ -53,26 +53,12 @@ class HArrayInsertTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    /**
-     * @dataProvider badArrayInsertProvider
-     *
-     * @param $item
-     * @param $exceptionMsg
-     */
-    public function testInsertBadThingsInHArray($item, $exceptionMsg)
+    public function testInsertObjects()
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
-
-        $this->arrList->insert($item);
-    }
-
-    public function badArrayInsertProvider()
-    {
-        return [
-            "DateTime" => [new \DateTime(), "DateTime cannot be contained within an HArray"],
-            "SPL Object" => [new \SplDoublyLinkedList(), "SplDoublyLinkedList cannot be contained within an HArray"],
-        ];
+        $object1 = new \DateTime();
+        $arrList = $this->arrList->insert($object1);
+        $this->assertTrue($arrList->contains($object1));
+        $this->assertEquals(4, $arrList->locate($object1));
     }
 
     /**

--- a/tests/Container/HArrayLocateTest.php
+++ b/tests/Container/HArrayLocateTest.php
@@ -50,25 +50,16 @@ class HArrayLocateTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    /**
-     * @dataProvider badArrayContainsProvider
-     *
-     * @param $item
-     * @param $exceptionMsg
-     */
-    public function testLocateBadThingsInHArray($item, $exceptionMsg)
+    public function testLocateObjectTypeInHArray()
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $timeStamp = new \DateTime();
+        $object = new \SplDoublyLinkedList();
 
-        $this->arrList->locate($item);
-    }
+        $arrList = $this->arrList
+            ->append($timeStamp)
+            ->insert($object);
 
-    public function badArrayContainsProvider()
-    {
-        return [
-            "DateTime" => [new \DateTime(), "DateTime cannot be contained within an HArray"],
-            "SPL Object" => [new \SplDoublyLinkedList(), "SplDoublyLinkedList cannot be contained within an HArray"],
-        ];
+        $this->assertEquals(4, $arrList->locate($timeStamp));
+        $this->assertEquals(5, $arrList->locate($object));
     }
 }

--- a/tests/Container/HArrayRemoveTest.php
+++ b/tests/Container/HArrayRemoveTest.php
@@ -45,26 +45,17 @@ class HArrayRemoveTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    /**
-     * @dataProvider badRemoveProvider
-     *
-     * @param $item
-     * @param $exceptionMsg
-     */
-    public function testBadObjectCannotBeRemovedFromArray($item, $exceptionMsg)
+    public function testArrayTypeRemoveObject()
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $timestamp = new \DateTime();
 
-        $this->arrDict->remove($item);
-    }
+        $arrList = $this->arrList->insert($timestamp, 2);
+        $arrDict = $this->arrDict->insert($timestamp, 2);
 
-    public function badRemoveProvider()
-    {
-        return [
-            "DateTime" => [new \DateTime(), "DateTime cannot be contained within an HArray"],
-            "SPL Object" => [new \SplDoublyLinkedList(), "SplDoublyLinkedList cannot be contained within an HArray"],
-        ];
+        $this->assertEquals($this->arrList, $arrList->remove($timestamp), "Object removed from list");
+        $this->assertEquals($arrList, $arrList->remove(new \SplDoublyLinkedList()), "Object not removed from list");
+        $this->assertEquals($this->arrDict, $arrDict->remove($timestamp), "Object removed from dict");
+        $this->assertEquals($arrDict, $arrDict->remove(new \SplDoublyLinkedList()), "Object not removed from dict");
     }
 
 }

--- a/tests/Functional/HArrayMapTest.php
+++ b/tests/Functional/HArrayMapTest.php
@@ -24,6 +24,9 @@ class HArrayMapTest extends \PHPUnit_Framework_TestCase
 
         $newArrList = $this->arrList->map($capitalizeList);
         $this->assertEquals("APPLE", $newArrList[0]);
+
+        $newArrDict = $this->arrDict->map($capitalizeList);
+        $this->assertEquals("APPLE", $newArrDict["a"]);
     }
 
 }

--- a/tests/HArrayTest.php
+++ b/tests/HArrayTest.php
@@ -47,31 +47,10 @@ class HArrayTest extends \PHPUnit_Framework_TestCase
             "integer: 0" => [0],
             "array" => [1, 2, 3],
             "ArrayObject" => [new \ArrayObject([0, 1, 2])],
+            "DateTime" => [new \DateTime()],
             "string" => ["a"],
             "HString" => [new HString("a string")],
             "HString of HString of ... " => [new HString(new HString(new HString(new HString("a string"))))],
-        ];
-    }
-
-    /**
-     * @dataProvider badArraysProvider
-     *
-     * @param $item
-     * @param $exceptionMsg
-     */
-    public function testCannotCreateArrayOfBadThings($item, $exceptionMsg)
-    {
-        $this->expectException("ErrorException");
-        $this->expectExceptionMessage($exceptionMsg);
-
-        new HArray($item);
-    }
-
-    public function badArraysProvider()
-    {
-        return [
-            "DateTime" => [new \DateTime(), "DateTime cannot be instantiated as an HArray"],
-            "SPL Object" => [new \SplDoublyLinkedList(), "SplDoublyLinkedList cannot be instantiated as an HArray"],
         ];
     }
 


### PR DESCRIPTION
Now one can build an HArray that contains objects. Yay!

This started out as a documentation update and a re-look at the HArray and HString constructors. I realized that I had some unnecessary checks for objects, when objects _should_ be able to be in an HArray.

A nice benefit to allowing objects into HArrays is that some of the associated methods have become much simpler. I will most likely take a look at migrating some of these methods back into the HArray and HString and away from the secondary classes.
