### PR TITLE
Reduce PHP compatibility from 5.6 to 5.5.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - "5.5"
   - "5.6"
   - "7.0"
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,12 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0"
+    "php": ">=5.5.9"
+  },
+  "config": {
+    "platform": {
+      "php": "5.5.9"
+    }
   },
   "autoload": {
     "psr-4": {"Haystack\\": "src"}
@@ -20,7 +25,7 @@
     "psr-4": {"Haystack\\Tests\\": "tests"}
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.0"
+    "phpunit/phpunit": "~4.8"
   },
   "extra": {
     "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d0a5dac70e9f41d583307c879266ea62",
-    "content-hash": "921a21ff5c825e520e59ee24be2bec03",
+    "hash": "a1ee09ea59333fe293ee10b4a3e72073",
+    "content-hash": "7b6a6273be31b13708ab9d8e390144f1",
     "packages": [],
     "packages-dev": [
         {
@@ -61,48 +61,6 @@
                 "instantiate"
             ],
             "time": "2015-06-14 21:17:01"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "e3abefcd7f106677fd352cd7c187d6c969aa9ddc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e3abefcd7f106677fd352cd7c187d6c969aa9ddc",
-                "reference": "e3abefcd7f106677fd352cd7c187d6c969aa9ddc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "time": "2015-11-07 22:20:37"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -217,30 +175,29 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "3.3.0",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "fe33716763b604ade4cb442c0794f5bd5ad73004"
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe33716763b604ade4cb442c0794f5bd5ad73004",
-                "reference": "fe33716763b604ade4cb442c0794f5bd5ad73004",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": ">=5.3.3",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "^1.4.2",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "phpunit/php-token-stream": "~1.3",
                 "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0|~2.0"
+                "sebastian/version": "~1.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "~4"
             },
             "suggest": {
                 "ext-dom": "*",
@@ -250,7 +207,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -276,7 +233,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-03-03 08:49:08"
+            "time": "2015-10-06 15:47:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -458,16 +415,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.3.0",
+            "version": "4.8.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "dd3001822b2df8f5add266020e3d2fd3c5db3ae9"
+                "reference": "a1066c562c52900a142a0e2bbf0582994671385e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/dd3001822b2df8f5add266020e3d2fd3c5db3ae9",
-                "reference": "dd3001822b2df8f5add266020e3d2fd3c5db3ae9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1066c562c52900a142a0e2bbf0582994671385e",
+                "reference": "a1066c562c52900a142a0e2bbf0582994671385e",
                 "shasum": ""
             },
             "require": {
@@ -476,22 +433,19 @@
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
+                "php": ">=5.3.3",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^3.3.0",
+                "phpunit/php-code-coverage": "~2.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": ">=1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.1",
+                "phpunit/phpunit-mock-objects": "~2.3",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0|~2.0",
+                "sebastian/version": "~1.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
             "suggest": {
@@ -503,7 +457,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "4.8.x-dev"
                 }
             },
             "autoload": {
@@ -529,30 +483,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-03-31 21:35:50"
+            "time": "2016-03-14 06:16:08"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.1.2",
+            "version": "2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "7c34c9bdde4131b824086457a3145e27dba10ca1"
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/7c34c9bdde4131b824086457a3145e27dba10ca1",
-                "reference": "7c34c9bdde4131b824086457a3145e27dba10ca1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.6",
+                "php": ">=5.3.3",
                 "phpunit/php-text-template": "~1.2",
                 "sebastian/exporter": "~1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "~4.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -560,7 +514,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -585,52 +539,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-03-24 05:58:25"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
+            "time": "2015-10-02 06:51:40"
         },
         {
             "name": "sebastian/comparator",
@@ -750,16 +659,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
+                "reference": "2292b116f43c272ff4328083096114f84ea46a56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
-                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/2292b116f43c272ff4328083096114f84ea46a56",
+                "reference": "2292b116f43c272ff4328083096114f84ea46a56",
                 "shasum": ""
             },
             "require": {
@@ -796,7 +705,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-02-26 18:40:46"
+            "time": "2016-05-04 07:59:13"
         },
         {
             "name": "sebastian/exporter",
@@ -916,52 +825,6 @@
             "time": "2015-10-12 03:26:01"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
-        },
-        {
             "name": "sebastian/recursion-context",
             "version": "1.0.2",
             "source": {
@@ -1015,70 +878,20 @@
             "time": "2015-11-11 19:50:13"
         },
         {
-            "name": "sebastian/resource-operations",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
-        },
-        {
             "name": "sebastian/version",
-            "version": "2.0.0",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
                 "shasum": ""
             },
-            "require": {
-                "php": ">=5.6"
-            },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1097,11 +910,11 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2015-06-21 13:59:46"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.4",
+            "version": "v3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -1155,7 +968,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.0"
+        "php": ">=5.5.9"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.5.9"
+    }
 }

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -21,7 +21,7 @@ $myArray = (new HArray($existingArray))->insert("orange", "o");
 
 ## Requirements
 
-* PHP >= 5.6
+* PHP >= 5.5.9
 * [composer](http://getcomposer.org)
 
 ## Main Classes of Haystack

--- a/src/Functional/HArrayFilterWithKey.php
+++ b/src/Functional/HArrayFilterWithKey.php
@@ -20,6 +20,16 @@ class HArrayFilterWithKey
      */
     public function filter(callable $func)
     {
+        if (!defined('ARRAY_FILTER_USE_KEY')) {
+            $return = [];
+            foreach ($this->arr as $k => $v) {
+                if (call_user_func($func, $k)) {
+                    $return[$k] = $v;
+                }
+            }
+            return $return;
+        }
+
         return array_filter($this->arr, $func, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Functional/HArrayFilterWithValueAndKey.php
+++ b/src/Functional/HArrayFilterWithValueAndKey.php
@@ -13,6 +13,17 @@ class HArrayFilterWithValueAndKey
 
     public function filter(callable $func)
     {
+        if (!defined('ARRAY_FILTER_USE_BOTH')) {
+            $return = [];
+            foreach ($this->arr as $k => $v) {
+                if (call_user_func($func, $v, $k)) {
+                    $return[$k] = $v;
+                }
+            }
+
+            return $return;
+        }
+
         return array_filter($this->arr, $func, ARRAY_FILTER_USE_BOTH);
     }
 }

--- a/tests/Container/HArrayInsertTest.php
+++ b/tests/Container/HArrayInsertTest.php
@@ -69,8 +69,7 @@ class HArrayInsertTest extends \PHPUnit_Framework_TestCase
      */
     public function testObjectCannotBeUsedAsArrayKey($key, $exceptionMsg)
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         $this->arrDict->insert("yobbo", $key);
     }

--- a/tests/Container/HArrayLocateTest.php
+++ b/tests/Container/HArrayLocateTest.php
@@ -55,8 +55,7 @@ class HArrayLocateTest extends \PHPUnit_Framework_TestCase
      */
     public function testElementNotFound($type, $checkThing, $message)
     {
-        $this->expectException("Haystack\\Container\\ElementNotFoundException");
-        $this->expectExceptionMessage($message);
+        $this->setExpectedException("Haystack\\Container\\ElementNotFoundException", $message);
 
         if ("list" === $type) {
             $this->arrList->locate($checkThing);

--- a/tests/Container/HArraySliceTest.php
+++ b/tests/Container/HArraySliceTest.php
@@ -108,8 +108,7 @@ class HArraySliceTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadArraySlice($type, $start, $length, $exceptionMsg)
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         if ("list" === $type) {
             $subArray = $this->arrList->slice($start, $length);

--- a/tests/Container/HStringAppendTest.php
+++ b/tests/Container/HStringAppendTest.php
@@ -38,8 +38,7 @@ class HStringAppendTest extends \PHPUnit_Framework_TestCase
 
     public function testNonScalarTypeCannotBeAddedToFoobar()
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage("Cannot concatenate an HString with a DateTime");
+        $this->setExpectedException("InvalidArgumentException", "Cannot concatenate an HString with a DateTime");
 
         $this->aString->append(new \DateTime());
     }

--- a/tests/Container/HStringContainsTest.php
+++ b/tests/Container/HStringContainsTest.php
@@ -49,8 +49,7 @@ class HStringContainsTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadTypesOfStringInFoobar($item, $exceptionMsg)
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         $this->aString->contains($item);
     }

--- a/tests/Container/HStringInsertTest.php
+++ b/tests/Container/HStringInsertTest.php
@@ -53,8 +53,7 @@ class HStringInsertTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadInsert($value, $key, $exceptionMsg)
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         $this->aString->insert($value, $key);
     }

--- a/tests/Container/HStringLocateTest.php
+++ b/tests/Container/HStringLocateTest.php
@@ -42,8 +42,7 @@ class HStringLocateTest extends \PHPUnit_Framework_TestCase
      */
     public function testCannotLocateTypesOfStringInFoober($checkString, $message)
     {
-        $this->expectException("Haystack\\Container\\ElementNotFoundException");
-        $this->expectExceptionMessage($message);
+        $this->setExpectedException("Haystack\\Container\\ElementNotFoundException", $message);
 
         $this->aString->locate($checkString);
     }
@@ -66,8 +65,7 @@ class HStringLocateTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadLocateTypesOfStringInFoobar($item, $exceptionMsg)
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         $this->aString->locate($item);
     }

--- a/tests/Container/HStringRemoveTest.php
+++ b/tests/Container/HStringRemoveTest.php
@@ -22,8 +22,7 @@ class HStringRemoveTest extends \PHPUnit_Framework_TestCase
 
     public function testCannotRemoveBadString()
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage("DateTime is neither a scalar value nor an HString");
+        $this->setExpectedException("InvalidArgumentException", "DateTime is neither a scalar value nor an HString");
 
         $this->aString->remove(new \DateTime());
     }

--- a/tests/Container/HStringSliceTest.php
+++ b/tests/Container/HStringSliceTest.php
@@ -88,8 +88,7 @@ class HStringSliceTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSlicing($start, $length, $exceptionMsg)
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         $this->aString->slice($start, $length);
     }

--- a/tests/Converter/ArrayToStringTest.php
+++ b/tests/Converter/ArrayToStringTest.php
@@ -63,8 +63,7 @@ class ArrayToStringTest extends \PHPUnit_Framework_TestCase
     {
         $arr = new HArray(["apple", "banana"]);
 
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage("glue must be a string");
+        $this->setExpectedException("InvalidArgumentException", "glue must be a string");
 
         $arr->ToHstring(3);
     }

--- a/tests/Converter/StringToArrayTest.php
+++ b/tests/Converter/StringToArrayTest.php
@@ -52,8 +52,7 @@ class StringToArrayTest extends \PHPUnit_Framework_TestCase
     {
         $hSTring = new HString("foobar");
 
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         $hSTring->toHArray($delim);
     }
@@ -74,8 +73,7 @@ class StringToArrayTest extends \PHPUnit_Framework_TestCase
     {
         $hString = new HString("foobar");
 
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         $hString->toHArray(" ", $limit);
     }

--- a/tests/Functional/HArrayFilterTest.php
+++ b/tests/Functional/HArrayFilterTest.php
@@ -76,8 +76,7 @@ class HArrayFilterTest extends \PHPUnit_Framework_TestCase
             return $vowels->contains($word[0]);
         };
 
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage("Invalid flag name");
+        $this->setExpectedException("InvalidArgumentException", "Invalid flag name");
 
         $this->arrList->filter($vowel, "boooth");
     }

--- a/tests/Functional/HStringFilterTest.php
+++ b/tests/Functional/HStringFilterTest.php
@@ -75,8 +75,7 @@ class HStringFilterTest extends \PHPUnit_Framework_TestCase
         $flag = "bad_flag";
         $exceptionMsg = "Invalid flag name";
 
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
         $even = $this->aString->filter(function ($key) {
             return $key % 2;
         }, $flag);

--- a/tests/HStringTest.php
+++ b/tests/HStringTest.php
@@ -60,8 +60,7 @@ class HStringTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateBadHStringOfThings($item, $exceptionMsg)
     {
-        $this->expectException("ErrorException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("ErrorException", $exceptionMsg);
 
         $this->aString = new HString($item);
     }
@@ -109,8 +108,7 @@ class HStringTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadUnserialize($item, $exceptionMsg)
     {
-        $this->expectException("InvalidArgumentException");
-        $this->expectExceptionMessage($exceptionMsg);
+        $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
         $this->aString->unserialize($item);
     }


### PR DESCRIPTION
> NOTE: This is a work-in-progress PR to allow Travis.CI running and visibility to code. Any and all commits will be squashed/rebased at will.

Reduce PHP compatibility to 5.5.9 to accommodate using Haystack in Drupal 8. PHP 5.5.9 is also the version shipped with Ubuntu 14.04 LTS.

Fixes Issue #10.
#### Changes
- Reduce `phpunit/phpunit` to 4.8 instead of 5.0 because 5.0 required PHP 5.6+.
