### PR TITLE
Change string to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@ All notable changes to this project will be documented in this file.
 This change log follows ideas put forth in [Keep a CHANGELOG](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased - 2016-04-07
+## Unreleased - 2016-05-12
 
 ### Changed
 * BC Break: ::locate($value) now throws an ElementNotFoundException when looking for something that does not exist
-* BC Break: HString classes now use a protected property of `$hString` if they're an `HString` and `$str` if they're a `String` since `string` is a reserved word in PHP7 
+* BC Break: HString classes now use a protected property of `$hString` if they're an `HString` and `$str` if they're a `String` since `string` is a reserved word in PHP7
+* BC Break: HString ::toHArray() now assumes no delimiter. ::toHArray() is now *mostly* an alias to `explode`. This means that the default string-array will be made of characters, not words.
 * Potential BC Break: HArray can now contain objects. So `new HArray(new \DateTime())` is now possible!
 * Clean up HString methods
 * Whitespace rules added for md, yml, and json files
@@ -55,7 +56,7 @@ OArray <--> String conversion
 ### Changed
 
 * OArray now has toOString() method. This is an alias to `implode`
-* OString now has toOArray() method. This is an alias to `explode`
+* OString now has toOArray() method. This is mostly an alias to `explode`
 
 ## [0.1.1](https://github.com/ericpoe/haystack/tree/v0.1.1) - 2015-07-27
 Documentation updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ OArray <--> String conversion
 
 * **Manual**
     * Move Pipelining section to be closer to the top since it's a good example of what can be done
-    * Add OArray & OString- specific sections
+    * Add OArray- & OString- specific sections
 
 ### Changed
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -382,7 +382,7 @@ use Haystack\HString;
 $string = (new HString("foo bar"))->toString(); // "foo bar"
 ```
 
-**toHArray($delim = " ", $limit = null)** - Converts an HString to an HArray. This is similar to PHP's [`explode`]
+**toHArray($delim = "", $limit = null)** - Converts an HString to an HArray. This is similar to PHP's [`explode`]
 (http://php.net/manual/en/function.explode.php).
 
 * **$delim** - The string to split the string on. This could be a single character or a phrase.
@@ -394,6 +394,7 @@ use Haystack\HArray;
 use Haystack\HString;
 
 $myString = new HString("I am the very model of a modern major-general");
+$chars = $myString->toHArray(); // HArray(["I", " ", "a", "m", " ", "t", "h", "e", " ", ..., "g", "e", "n", "e", "r", "a", "l"]);
 $words = $myString->toHArray(" "); // HArray(["I", "am", "the", "very", "model", "of", "a", "modern", "major-general"]);
 $wordGroups = $myString->toHArray(" modern "); // HArray(["I am the very model of a", "major-general"]);
 $someWords = $myString->toHArray(" ", 4); // HArray (["I", "am", "the", "very model of a modern major-general"]);

--- a/src/Converter/StringToArray.php
+++ b/src/Converter/StringToArray.php
@@ -18,7 +18,7 @@ class StringToArray
      * @param string $str
      * @param string $delim
      */
-    public function __construct($str, $delim = " ")
+    public function __construct($str, $delim = "")
     {
         $this->str = $str;
 
@@ -35,7 +35,7 @@ class StringToArray
      */
     public function stringToArray($limit)
     {
-        if (empty($this->delim)) {
+        if (is_null($this->delim)) {
             $this->arr = $this->noDelimExplode();
             return $this->arr;
         }
@@ -58,7 +58,7 @@ class StringToArray
      */
     private function noDelimExplode()
     {
-        return explode(" ", $this->str);
+        return str_split($this->str);
     }
 
     /**

--- a/src/HString.php
+++ b/src/HString.php
@@ -239,7 +239,7 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
      * @return HArray
      * @throws \InvalidArgumentException
      */
-    public function toHArray($delim = " ", $limit = null)
+    public function toHArray($delim = "", $limit = null)
     {
         if (empty($this->str)) {
             return new HArray();
@@ -406,7 +406,9 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
      */
     public function sum()
     {
-        return $this->toHArray()->sum();
+        $values = new HArray(str_getcsv(str_ireplace(" ", "", $this->str)));
+
+        return $values->sum();
     }
 
     /**
@@ -416,6 +418,8 @@ class HString implements \Iterator, \ArrayAccess, \Serializable, \Countable, Con
      */
     public function product()
     {
-        return $this->toHArray()->product();
+        $values = new HArray(str_getcsv(str_ireplace(" ", "", $this->str)));
+
+        return $values->product();
     }
 }

--- a/tests/Converter/StringToArrayTest.php
+++ b/tests/Converter/StringToArrayTest.php
@@ -26,19 +26,20 @@ class StringToArrayTest extends \PHPUnit_Framework_TestCase
 
         return [
             "Empty String" => [new HString(), null, null, new HArray()],
-            "String of integers with null delims" => [new HString("1 2 3 4 5"), null, null, new HArray([1, 2, 3, 4, 5])],
-            "String of integers with blank string delims" => [new HString("1 2 3 4 5"), "", null, new HArray([1, 2, 3, 4, 5])],
+            "String of integers with null delims" => [new HString("1 2 3 4 5"), null, null, new HArray([1, " ", 2, " " , 3," ", 4, " ", 5])],
+            "String of integers with blank string delims" => [new HString("1 2 3 4 5"), null, null, new HArray([1, " ", 2, " " , 3," ", 4, " ", 5])],
             "String of integers with space delims" => [new HString("1 2 3 4 5"), " ", null, new HArray([1, 2, 3, 4, 5])],
             "String of integers with comma delims" => [new HString("1, 2, 3, 4, 5"), ",", null, new HArray([1, 2, 3, 4, 5])],
             "String of integers with non-existent delims" => [new HString("1, 2, 3, 4, 5"), "foo", null, new HArray(["1, 2, 3, 4, 5"])],
             "String of integers with HString space delims" => [new HString("1 2 3 4 5"), new HString(" "), null, new HArray([1, 2, 3, 4, 5])],
             "String of integers with HString comma delims" => [new HString("1, 2, 3, 4, 5"), new HString(","), null, new HArray([1, 2, 3, 4, 5])],
-            "String of words with spaces" => [new HString($jabberwocky), " ", null, new HArray(["'Twas", "brillig", "and", "the", "slithy", "toves"])],
-            "String of words with colons" => [new HString($jabberwockyColon), ":", null, new HArray(["'Twas", "brillig", "and", "the", "slithy", "toves"])],
-            "String of integers with spaces & limit" => [new HString("1 2 3 4 5"), " ", 3, new HArray([1, 2, "3 4 5"])],
-            "String of integers with commas & limit" => [new HString("1, 2, 3, 4, 5"), ", ", 3, new HArray([1, 2, "3, 4, 5"])],
-            "String of words with spaces & limit" => [new HString($jabberwocky), " ", 3, new HArray(["'Twas", "brillig", "and the slithy toves"])],
-            "String of words with colons & limit" => [new HString($jabberwockyColon), ":", 3, new HArray(["'Twas", "brillig", "and:the:slithy:toves"])],
+            "String of words with null delims" => [new HString($jabberwocky), null, null, new HArray(["'", "T", "w", "a", "s", " ", "b", "r", "i", "l", "l", "i", "g", " ", "a", "n", "d", " ", "t", "h", "e", " ", "s", "l", "i", "t", "h", "y", " ", "t", "o", "v", "e", "s"])],
+            "String of words with space delims" => [new HString($jabberwocky), " ", null, new HArray(["'Twas", "brillig", "and", "the", "slithy", "toves"])],
+            "String of words with colon delims" => [new HString($jabberwockyColon), ":", null, new HArray(["'Twas", "brillig", "and", "the", "slithy", "toves"])],
+            "String of integers with space delims & limit" => [new HString("1 2 3 4 5"), " ", 3, new HArray([1, 2, "3 4 5"])],
+            "String of integers with comma delims & limit" => [new HString("1, 2, 3, 4, 5"), ", ", 3, new HArray([1, 2, "3, 4, 5"])],
+            "String of words with space delims & limit" => [new HString($jabberwocky), " ", 3, new HArray(["'Twas", "brillig", "and the slithy toves"])],
+            "String of words with colon delims & limit" => [new HString($jabberwockyColon), ":", 3, new HArray(["'Twas", "brillig", "and:the:slithy:toves"])],
         ];
     }
 


### PR DESCRIPTION
Some wrong assumptions were made when I had originally created the `toHArray()` method for `HString`. I _knew_ that strings are essentially an array of characters, but I made them an array of words. Dumb! Dumb! Dumb!

This PR corrects that fallacious assumption.
