### PR TITLE
Enable UTF-8 encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ php:
   - "7.1"
   - hhvm
 
-sudo: required
-dist: trusy
-group: edge
+dist: trusty
+sudo: false
+group: beta
 
 install: travis_retry composer install --no-interaction --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - "5.5"
   - "5.6"
   - "7.0"
+  - "7.1"
   - hhvm
 
 sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@ All notable changes to this project will be documented in this file.
 This change log follows ideas put forth in [Keep a CHANGELOG](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased - 2016-11-24
+## Unreleased - 2016-12-08
 
 ### Added
 * Now with UTF-8 strings!
+
+### Removed
+* Removed support for PHP 5.5 since it doesn't support UTF-8 as well as I'd like
 
 ### Changed
 * BC Break: ::locate($value) now throws an ElementNotFoundException when looking for something that does not exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 This change log follows ideas put forth in [Keep a CHANGELOG](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased - 2016-05-19
+## Unreleased - 2016-11-24
+
+### Added
+* Now with UTF-8 strings!
 
 ### Changed
 * BC Break: ::locate($value) now throws an ElementNotFoundException when looking for something that does not exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * Now with UTF-8 strings!
+* Added support for PHP 7.1
 
 ### Removed
 * Removed support for PHP 5.5 since it doesn't support UTF-8 as well as I'd like

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Packagist Version](https://img.shields.io/packagist/v/ericpoe/haystack.svg?style=flat-square)](https://packagist.org/packages/ericpoe/haystack)
 
 # Haystack
-Forget Haystack vs Needle order, the object *IS* the Haystack. Haystack is a library that allows for pipelining and
-immutable structures.
+Forget Haystack vs Needle order, the object *IS* the Haystack. Haystack is a library that allows for pipelining,
+immutable structures, and UTF-8 strings.
 
 ## Install
 Haystack is installable as a [Composer](http://getcomposer.org) package:

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9"
+    "php": ">=5.6.0"
   },
   "config": {
     "platform": {
-      "php": "5.5.9"
+      "php": "5.6.0"
     }
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "psr-4": {"Haystack\\Tests\\": "tests"}
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8"
+    "phpunit/phpunit": "^5"
   },
   "extra": {
     "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a1ee09ea59333fe293ee10b4a3e72073",
-    "content-hash": "7b6a6273be31b13708ab9d8e390144f1",
+    "hash": "6c3fa1df18b5180ed11e6b6dd2491328",
+    "content-hash": "08e50d9d017b5b0882e5e1db7e66a8e6",
     "packages": [],
     "packages-dev": [
         {
@@ -63,38 +63,129 @@
             "time": "2015-06-14 21:17:01"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "name": "myclabs/deep-copy",
+            "version": "1.5.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/399c1f9781e222f6eb6cc238796f5200d1b7f108",
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
             },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2016-10-31 17:19:45"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27 11:43:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
                         "src/"
                     ]
                 }
@@ -106,39 +197,88 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-09-30 07:12:33"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.6.0",
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-11-25 06:54:22"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1",
-                "sebastian/recursion-context": "~1.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -171,43 +311,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "903fd6318d0a90b4770a009ff73e4a4e9c437929"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/903fd6318d0a90b4770a009ff73e4a4e9c437929",
+                "reference": "903fd6318d0a90b4770a009ff73e4a4e9c437929",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": "^5.6 || ^7.0",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
+                "ext-xdebug": ">=2.4.0",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -233,20 +374,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2016-11-28 16:00:31"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -280,7 +421,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -325,20 +466,23 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
             },
             "type": "library",
             "autoload": {
@@ -362,20 +506,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -411,44 +555,54 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.24",
+            "version": "5.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1066c562c52900a142a0e2bbf0582994671385e"
+                "reference": "de164acc2f2bb0b79beb892a36260264b2a03233"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1066c562c52900a142a0e2bbf0582994671385e",
-                "reference": "a1066c562c52900a142a0e2bbf0582994671385e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de164acc2f2bb0b79beb892a36260264b2a03233",
+                "reference": "de164acc2f2bb0b79beb892a36260264b2a03233",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.3",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": ">=1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
                 "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -457,7 +611,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -483,30 +637,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-03-14 06:16:08"
+            "time": "2016-12-09 02:48:53"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -514,7 +671,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -539,26 +696,71 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2016-12-08 20:27:08"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -603,7 +805,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -659,28 +861,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.6",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "2292b116f43c272ff4328083096114f84ea46a56"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/2292b116f43c272ff4328083096114f84ea46a56",
-                "reference": "2292b116f43c272ff4328083096114f84ea46a56",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -705,33 +907,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-04 07:59:13"
+            "time": "2016-11-26 07:53:53"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
+                "ext-mbstring": "*",
                 "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -771,7 +974,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2016-11-19 08:54:04"
         },
         {
             "name": "sebastian/global-state",
@@ -825,17 +1028,63 @@
             "time": "2015-10-12 03:26:01"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-11-19 07:35:10"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -847,7 +1096,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -875,23 +1124,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-19 07:33:16"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -910,29 +1209,35 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.6",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0047c8366744a16de7516622c5b7355336afae96"
+                "reference": "f2300ba8fbb002c028710b92e1906e7457410693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0047c8366744a16de7516622c5b7355336afae96",
-                "reference": "0047c8366744a16de7516622c5b7355336afae96",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f2300ba8fbb002c028710b92e1906e7457410693",
+                "reference": "f2300ba8fbb002c028710b92e1906e7457410693",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -959,7 +1264,57 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:55:57"
+            "time": "2016-11-18 21:17:59"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6c3fa1df18b5180ed11e6b6dd2491328",
-    "content-hash": "08e50d9d017b5b0882e5e1db7e66a8e6",
+    "hash": "87ec7c5def2bd47fe86b6cffc380c110",
+    "content-hash": "8178114c5bb67419de8b2eb3648dbf5d",
     "packages": [],
     "packages-dev": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -968,10 +968,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.9"
+        "php": ">=5.6.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.5.9"
+        "php": "5.6.0"
     }
 }

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -21,7 +21,7 @@ $myArray = (new HArray($existingArray))->insert("orange", "o");
 
 ## Requirements
 
-* PHP >= 5.5.9
+* PHP >= 5.6
 * [composer](http://getcomposer.org)
 
 ## Main Classes of Haystack

--- a/src/Container/HStringContains.php
+++ b/src/Container/HStringContains.php
@@ -12,9 +12,12 @@ class HStringContains
     /** @var string */
     private $value;
 
+    private $encoding;
+
     public function __construct(HString $hString)
     {
         $this->str = $hString->toString();
+        $this->encoding = $hString->getEncoding();
     }
 
     /**
@@ -41,6 +44,6 @@ class HStringContains
      */
     private function containsValue()
     {
-        return false !== strpos($this->str, $this->value);
+        return false !== mb_strpos($this->str, $this->value, null, $this->encoding);
     }
 }

--- a/src/Container/HStringInsert.php
+++ b/src/Container/HStringInsert.php
@@ -18,17 +18,32 @@ class HStringInsert
     {
         if (is_scalar($value) || $value instanceof HString) {
             if (is_null($key)) {
-                $key = strlen($this->hString);
+                $key = $this->hString->count();
             } elseif (is_numeric($key)) {
                 $key = (int) $key;
             } else {
                 throw new \InvalidArgumentException("Invalid array key");
             }
 
-            return substr_replace($this->hString, $value, $key, 0);
+            return $this->getPrefix($key). $value . $this->getSuffix($key);
         }
 
         throw new \InvalidArgumentException(sprintf("Cannot insert %s into an HString", Helper::getType($value)));
+    }
+
+    private function getPrefix($key)
+    {
+        $length = $key >= 0 ? $key: $this->hString->count() - 1;
+
+        return mb_substr($this->hString, 0, $length, $this->hString->getEncoding());
+    }
+
+    private function getSuffix($key)
+    {
+        $start = $key >= 0 ? $key : $this->hString->count() + $key;
+        $length = $key >= 0 ? $this->hString->count() : $this->hString->count() + $key;
+
+        return mb_substr($this->hString, $start, $length, $this->hString->getEncoding());
     }
 
 }

--- a/src/Container/HStringLocate.php
+++ b/src/Container/HStringLocate.php
@@ -21,7 +21,7 @@ class HStringLocate
     public function locate($value)
     {
         if ($this->hString->contains($value)) {
-            return strpos($this->hString, (string) $value);
+            return mb_strpos($this->hString, (string) $value, null, $this->hString->getEncoding());
         }
 
         throw new ElementNotFoundException($value);

--- a/src/Container/HStringRemove.php
+++ b/src/Container/HStringRemove.php
@@ -20,10 +20,17 @@ class HStringRemove
     public function remove($value)
     {
         $key = $this->hString->locate($value);
-        $startString = $this->hString->slice(0, $key);
-        $endString = $this->hString->slice($key + 1);
 
-        return $startString->insert($endString);
+        return new HString($this->getPrefix($key) . $this->getSuffix($key));
     }
 
+    private function getPrefix($length)
+    {
+        return mb_substr($this->hString, 0, $length, $this->hString->getEncoding());
+    }
+
+    private function getSuffix($start)
+    {
+        return mb_substr($this->hString, $start + 1, $this->hString->count() - $start, $this->hString->getEncoding());
+    }
 }

--- a/src/Container/HStringSlice.php
+++ b/src/Container/HStringSlice.php
@@ -13,7 +13,7 @@ class HStringSlice
      */
     public function __construct(HString $hString)
     {
-        $this->str = $hString->toString();
+        $this->str = $hString;
     }
 
     /**
@@ -31,10 +31,6 @@ class HStringSlice
             throw new \InvalidArgumentException("Slice parameter 2, \$length, must be null or an integer");
         }
 
-        if (is_null($length)) {
-            return substr($this->str, $start);
-        }
-
-        return substr($this->str, $start, $length);
+        return mb_substr($this->str, $start, $length, $this->str->getEncoding());
     }
 }

--- a/src/Converter/StringToArray.php
+++ b/src/Converter/StringToArray.php
@@ -16,7 +16,7 @@ class StringToArray
 
     /**
      * @param string $str
-     * @param string $delim
+     * @param string | HString $delim
      */
     public function __construct($str, $delim = "")
     {
@@ -58,7 +58,7 @@ class StringToArray
      */
     private function noDelimExplode()
     {
-        return str_split($this->str);
+        return preg_split('//u', $this->str, -1, PREG_SPLIT_NO_EMPTY);
     }
 
     /**

--- a/src/Functional/FilterWithKey.php
+++ b/src/Functional/FilterWithKey.php
@@ -20,17 +20,6 @@ class FilterWithKey
      */
     public function filter(callable $func)
     {
-        if (!defined('ARRAY_FILTER_USE_KEY')) {
-            $return = [];
-            foreach ($this->arr as $k => $v) {
-                if (call_user_func($func, $k)) {
-                    $return[$k] = $v;
-                }
-            }
-
-            return $return;
-        }
-
         return array_filter($this->arr, $func, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Functional/FilterWithValueAndKey.php
+++ b/src/Functional/FilterWithValueAndKey.php
@@ -20,17 +20,6 @@ class FilterWithValueAndKey
      */
     public function filter(callable $func)
     {
-        if (!defined('ARRAY_FILTER_USE_BOTH')) {
-            $return = [];
-            foreach ($this->arr as $k => $v) {
-                if (call_user_func($func, $v, $k)) {
-                    $return[$k] = $v;
-                }
-            }
-
-            return $return;
-        }
-
         return array_filter($this->arr, $func, ARRAY_FILTER_USE_BOTH);
     }
 }

--- a/tests/Container/HStringAppendTest.php
+++ b/tests/Container/HStringAppendTest.php
@@ -5,34 +5,75 @@ use Haystack\HString;
 
 class HStringAppendTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var HString */
-    protected $aString;
-
-    protected function setUp()
-    {
-        $this->aString = new HString("foobar");
-    }
-
     /**
      * @dataProvider stringAppendProvider()
      *
+     * @param HString $target
      * @param $babyString
-     * @param $expected
+     * @param HString $expected
      */
-    public function testTypesOfStringAppendToFoobar($babyString, $expected)
+    public function testTypesOfStringAppendToFoobar(HString $target, $babyString, HString $expected)
     {
-        $newString = $this->aString->append($babyString);
+        $newString = $target->append($babyString);
 
         $this->assertEquals(sprintf("%s", $expected), sprintf("%s", $newString));
     }
 
     public function stringAppendProvider()
     {
+        $aString = new HString("foobar");
+        $utf8String = new HString("ɹɐqooɟ");
         return [
-            "Append a normal string" => ["babyString" => "baz", "expected" => "foobarbaz"],
-            "Append an HString" => ["babyString" => new HString('baz'), "expected" => "foobarbaz"],
-            "Append an integer" => ["babyString" => 5, "expected" => "foobar5"],
-            "Append a double" => ["babyString" => 5.1, "expected" => "foobar5.1"],
+            "ASCII HString: Append a normal string" => [
+                $aString,
+                "babyString" => "baz",
+                "expected" => new HString("foobarbaz")
+            ],
+            "ASCII HString: Append an HString" => [
+                $aString,
+                "babyString" => new HString("baz"),
+                "expected" => new HString("foobarbaz")
+            ],
+            "ASCII HString: Append a UTF-8 HString" => [
+                $aString,
+                "babyString" => new HString("zɐq"),
+                "expected" => new HString("foobarzɐq")
+            ],
+            "ASCII HString: Append an integer" => [
+                $aString,
+                "babyString" => 5,
+                "expected" => new HString("foobar5")
+            ],
+            "ASCII HString: Append a double" => [
+                $aString,
+                "babyString" => 5.1,
+                "expected" => new HString("foobar5.1")
+            ],
+            "UTF-8 HString: Append a normal string" => [
+                $utf8String,
+                "babyString" => "baz",
+                "expected" => new HString("ɹɐqooɟbaz")
+            ],
+            "UTF-8 HString: Append an HString" => [
+                $utf8String,
+                "babyString" => new HString("baz"),
+                "expected" => new HString("ɹɐqooɟbaz")
+            ],
+            "UTF-8 HString: Append a UTF-8 HString" => [
+                $utf8String,
+                "babyString" => new HString("zɐq"),
+                "expected" => new HString("ɹɐqooɟzɐq")
+            ],
+            "UTF-8 HString: Append an integer" => [
+                $utf8String,
+                "babyString" => 5,
+                "expected" => new HString("ɹɐqooɟ5")
+            ],
+            "UTF-8 HString: Append a double" => [
+                $utf8String,
+                "babyString" => 5.1,
+                "expected" => new HString("ɹɐqooɟ5.1")
+            ],
         ];
     }
 
@@ -40,6 +81,6 @@ class HStringAppendTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException("InvalidArgumentException", "Cannot concatenate an HString with a DateTime");
 
-        $this->aString->append(new \DateTime());
+        (new HString("foobar"))->append(new \DateTime());
     }
 }

--- a/tests/Container/HStringContainsTest.php
+++ b/tests/Container/HStringContainsTest.php
@@ -5,38 +5,42 @@ use Haystack\HString;
 
 class HStringContainsTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var \Haystack\HString */
-    protected $aString;
-
-    protected function setUp()
-    {
-        $this->aString = new HString("foobar");
-    }
-
     /**
      * @dataProvider stringContainsProvider
      *
-     * @param $checkString
-     * @param $expectedBool
+     * @param string|HString $target
+     * @param string|HString $checkString
+     * @param bool $expectedBool
      */
-    public function testTypesOfStringInFoobar($checkString, $expectedBool)
+    public function testTypesOfStringInFoobar($target, $checkString, $expectedBool)
     {
-        $var = $this->aString->contains($checkString);
+        $var = $target->contains($checkString);
         $expectedBool ? $this->assertTrue($var) : $this->assertFalse($var);
     }
 
     public function stringContainsProvider()
     {
+        $aString = new HString("foobar");
+        $utf8String = new HString("ɹɐqooɟ");
         return [
-            "String known-present" => ["oob", true],
-            "String known-missing" => ["baz", false],
-            "String letter known-present" => ["b", true],
-            "String letter known-missing" => ["z", false],
-            "HString known-present" => [new HString('oob'), true],
-            "HString letter known-present" => [new HString('b'), true],
-            "HString known-missing" => [new HString('baz'), false],
-            "HString letter known-missing" => [new HString('z'), false],
-            "Integer known-missing" => [42, false],
+            "ASCII: String known-present" => [$aString, "oob", true],
+            "ASCII: String known-missing" => [$aString, "baz", false],
+            "ASCII: String letter known-present" => [$aString, "b", true],
+            "ASCII: String letter known-missing" => [$aString, "z", false],
+            "ASCII: HString known-present" => [$aString, new HString('oob'), true],
+            "ASCII: HString letter known-present" => [$aString, new HString('b'), true],
+            "ASCII: HString known-missing" => [$aString, new HString('baz'), false],
+            "ASCII: HString letter known-missing" => [$aString, new HString('z'), false],
+            "ASCII: Integer known-missing" => [$aString, 42, false],
+            "UTF-8: String known-present" => [$utf8String, "ɐqo", true],
+            "UTF-8: String known-missing" => [$utf8String, "zɐq", false],
+            "UTF-8: String letter known-present" => [$utf8String, "q", true],
+            "UTF-8: String letter known-missing" => [$utf8String, "z", false],
+            "UTF-8: HString known-present" => [$utf8String, new HString('ɐqo'), true],
+            "UTF-8: HString letter known-present" => [$utf8String, new HString('q'), true],
+            "UTF-8: HString known-missing" => [$utf8String, new HString('zɐq'), false],
+            "UTF-8: HString letter known-missing" => [$utf8String, new HString('z'), false],
+            "UTF-8: Integer known-missing" => [$utf8String, 42, false],
         ];
     }
 
@@ -64,7 +68,7 @@ class HStringContainsTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
-        $this->aString->contains($item);
+        (new HString("foobar"))->contains($item);
     }
 
     public function badTypesOfStringInFoobar()

--- a/tests/Container/HStringInsertTest.php
+++ b/tests/Container/HStringInsertTest.php
@@ -5,41 +5,47 @@ use Haystack\HString;
 
 class HStringInsertTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var HString */
-    protected $aString;
-
-    protected function setUp()
-    {
-        $this->aString = new HString("foobar");
-    }
-
     /**
      * @dataProvider stringInsertProvider()
      *
-     * @param $babyString
-     * @param $location
-     * @param $expected
+     * @param HString $target
+     * @param string|HString $babyString
+     * @param integer $location
+     * @param HString $expected
      */
-    public function testTypesOfStringInsert($babyString, $location, $expected)
+    public function testTypesOfStringInsert(HString $target, $babyString, $location, HString $expected)
     {
-        $newString = $this->aString->insert($babyString, $location);
+        $newString = $target->insert($babyString, $location);
 
         $this->assertEquals(sprintf("%s", $expected), sprintf("%s", $newString));
     }
 
     public function stringInsertProvider()
     {
+        $aString = new HString("foobar");
+        $utf8String = new HString("ɹɐqooɟ");
+
         return [
-            "String: insert at position 1" => ["baz", 1, "fbazoobar"],
-            "String: insert at position -1" => ["baz", -1, "foobabazr"],
-            "String: insert at end" => ["baz", null, "foobarbaz"],
-            "String: insert Integer" => [1, 3, "foo1bar"],
-            "String: insert Double" => [1.1, 3, "foo1.1bar"],
-            "HString: insert at position 1" => [new HString("baz"), 1, "fbazoobar"],
-            "HString: insert at position -1" => [new HString("baz"), -1, "foobabazr"],
-            "HString: insert at end" => [new HString("baz"), null, "foobarbaz"],
-            "HString: insert Integer" => [new HString(1), 3, "foo1bar"],
-            "HString: insert Double" => [new HString(1.1), 3, "foo1.1bar"],
+            "ASCII String: insert at position 1" => [$aString, "baz", 1, new HString("fbazoobar")],
+            "ASCII String: insert at position -1" => [$aString, "baz", -1, new HString("foobabazr")],
+            "ASCII String: insert at end" => [$aString, "baz", null, new HString("foobarbaz")],
+            "ASCII String: insert Integer" => [$aString, 1, 3, new HString("foo1bar")],
+            "ASCII String: insert Double" => [$aString, 1.1, 3, new HString("foo1.1bar")],
+            "ASCII HString: insert at position 1" => [$aString, new HString("baz"), 1, new HString("fbazoobar")],
+            "ASCII HString: insert at position -1" => [$aString, new HString("baz"), -1, new HString("foobabazr")],
+            "ASCII HString: insert at end" => [$aString, new HString("baz"), null, new HString("foobarbaz")],
+            "ASCII HString: insert Integer" => [$aString, new HString(1), 3, new HString("foo1bar")],
+            "ASCII HString: insert Double" => [$aString, new HString(1.1), 3, new HString("foo1.1bar")],
+            "UTF-8 String: insert at position 1" => [$utf8String, "baz", 1, new HString("ɹbazɐqooɟ")],
+            "UTF-8 String: insert at position -1" => [$utf8String, "baz", -1, new HString("ɹɐqoobazɟ")],
+            "UTF-8 String: insert at end" => [$utf8String, "baz", null, new HString("ɹɐqooɟbaz")],
+            "UTF-8 String: insert Integer" => [$utf8String, 1, 3, new HString("ɹɐq1ooɟ")],
+            "UTF-8 String: insert Double" => [$utf8String, 1.1, 3, new HString("ɹɐq1.1ooɟ")],
+            "UTF-8 HString: insert at position 1" => [$utf8String, new HString("baz"), 1, new HString("ɹbazɐqooɟ")],
+            "UTF-8 HString: insert at position -1" => [$utf8String, new HString("baz"), -1, new HString("ɹɐqoobazɟ")],
+            "UTF-8 HString: insert at end" => [$utf8String, new HString("baz"), null, new HString("ɹɐqooɟbaz")],
+            "UTF-8 HString: insert Integer" => [$utf8String, new HString(1), 3, new HString("ɹɐq1ooɟ")],
+            "UTF-8 HString: insert Double" => [$utf8String, new HString(1.1), 3, new HString("ɹɐq1.1ooɟ")],
         ];
     }
 
@@ -55,7 +61,7 @@ class HStringInsertTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
-        $this->aString->insert($value, $key);
+        (new HString("foobar"))->insert($value, $key);
     }
 
     public function badInsertProvider()
@@ -67,5 +73,4 @@ class HStringInsertTest extends \PHPUnit_Framework_TestCase
             "Insert at non-integer key" => ["apple", "a", "Invalid array key"],
         ];
     }
-
 }

--- a/tests/Container/HStringLocateTest.php
+++ b/tests/Container/HStringLocateTest.php
@@ -5,32 +5,29 @@ use Haystack\HString;
 
 class HStringLocateTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var HString */
-    protected $aString;
-
-    protected function setUp()
-    {
-        $this->aString = new HString("foobar");
-    }
-
     /**
      * @dataProvider stringLocateProvider()
      *
-     * @param $checkString
-     * @param $expected
+     * @param HString $target
+     * @param string | HString $checkString
+     * @param integer $expected
      */
-    public function testLocateTypesOfStringInFoobar($checkString, $expected)
+    public function testLocateTypesOfStringInFoobar(HString $target, $checkString, $expected)
     {
-        $var = $this->aString->locate($checkString);
+        $var = $target->locate($checkString);
         $this->assertEquals($expected, $var);
     }
 
     public function stringLocateProvider()
     {
-        return [
-            "String known-present" => ["oob", 1],
-            "HString known-present" => [new HString('oob'), 1],
+        $aString = new HString("foobar");
+        $utf8String = new HString("ɹɐqooɟ");
 
+        return [
+            "ASCII: String known-present" => [$aString, "oob", 1],
+            "ASCII: HString known-present" => [$aString, new HString('oob'), 1],
+            "UTF-8: String known-present" => [$utf8String, "ɐqo", 1],
+            "UTF-8: HString known-present" => [$utf8String, new HString('ɐqo'), 1],
         ];
     }
 
@@ -58,7 +55,7 @@ class HStringLocateTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException("Haystack\\Container\\ElementNotFoundException", $message);
 
-        $this->aString->locate($checkString);
+        (new HString("foobar"))->locate($checkString);
     }
 
     public function stringBadLocateProvider()
@@ -81,7 +78,7 @@ class HStringLocateTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
-        $this->aString->locate($item);
+        (new HString("foobar"))->locate($item);
     }
 
     public function badLocateTypesOfStringInFoobarProvider()

--- a/tests/Container/HStringRemoveTest.php
+++ b/tests/Container/HStringRemoveTest.php
@@ -8,15 +8,22 @@ class HStringRemoveTest extends \PHPUnit_Framework_TestCase
     /** @var HString */
     protected $aString;
 
+    /** @var HString */
+    protected $utf8String;
+
     protected function setUp()
     {
         $this->aString = new HString("foobar");
+        $this->utf8String = new HString("ɹɐqooɟ");
     }
 
     public function testTypesOfStringRemove()
     {
         $newString = $this->aString->remove("o");
         $this->assertEquals(new HString("fobar"), $newString);
+
+        $newString = $this->utf8String->remove("o");
+        $this->assertEquals(new HString("ɹɐqoɟ"), $newString);
     }
 
     public function testCannotRemoveBadString()

--- a/tests/Container/HStringSliceTest.php
+++ b/tests/Container/HStringSliceTest.php
@@ -5,100 +5,104 @@ use Haystack\HString;
 
 class HStringSliceTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var HString */
-    protected $aString;
-
-    protected function setUp()
-    {
-        $this->aString = new HString("foobar");
-    }
-
     /**
      * @dataProvider providerFirstPartOfTypesOfStringUsingSlice
      *
+     * @param HString $target
      * @param $expected
      */
-    public function testGetFirstPartOfTypesOfStringUsingSlice($expected)
+    public function testGetFirstPartOfTypesOfStringUsingSlice(HString $target, $expected)
     {
-
-        $this->assertEquals($expected, $this->aString->slice(0, 4));
-
+        $this->assertEquals($expected, $target->slice(0, 4));
     }
 
     public function providerFirstPartOfTypesOfStringUsingSlice()
     {
         return [
-            "String" => ["foob"],
-            "HString" => [new HString("foob")],
+            "String" => [new HString("foobar"), "foob"],
+            "ASCII HString" => [new HString("foobar"), new HString("foob")],
+            "UTF-8 HString" => [new HString("ɹɐqooɟ"), new HString("ɹɐqo")],
         ];
     }
 
     /**
      * @dataProvider providerLastPartOfTypesOfStringUsingSlice
      *
+     * @param HString $target
      * @param $expected
      */
-    public function testGetLastPartOfTypesOfStringUsingSlice($expected)
+    public function testGetLastPartOfTypesOfStringUsingSlice(HString $target, $expected)
     {
-        $this->assertEquals($expected, $this->aString->slice(-4));
+        $this->assertEquals($expected, $target->slice(-4));
     }
 
     public function providerLastPartOfTypesOfStringUsingSlice()
     {
         return [
-            "String" => ["obar"],
-            "HString" => [new HString("obar")],
+            "HString" => [new HString("foobar"), new HString("obar")],
+            "UTF-8 HString" => [new HString("ɹɐqooɟ"), new HString("qooɟ")],
         ];
     }
 
     /**
      * @dataProvider middlePartOfStringProvider
      *
-     * @param $start
-     * @param $finish
-     * @param $expected
+     * @param HString $target
+     * @param HString $expected
+     * @param integer $start
+     * @param integer $finish
      */
-    public function testGetMiddlePartOfTypesOfStringUsingSlice($start, $finish, $expected)
+    public function testGetMiddlePartOfTypesOfStringUsingSlice(HString $target, HString $expected, $start, $finish)
     {
-        $this->assertEquals($expected, $this->aString->slice($start, $finish));
+        $this->assertEquals($expected, $target->slice($start, $finish));
     }
 
     public function middlePartOfStringProvider()
     {
         return [
-            "String: Negative finish, middle" => [2, -2, "ob"],
-            "String: Negative start & finish, middle" => [-4, -2, "ob"],
-            "String: normal middle" => [2, 2, "ob"],
-            "String: null finish" => [2, null, "obar"],
-            "String: overflow finish" => [2, 2000, "obar"],
-            "HString: Negative finish, middle" => [2, -2, new HString("ob")],
-            "HString: Negative start & finish, middle" => [-4, -2, new HString("ob")],
-            "HString: normal middle" => [2, 2, new HString("ob")],
-            "HString: null finish" => [2, null, new HString("obar")],
-            "HString: overflow finish" => [2, 2000, new HString("obar")],
+            "ASCII HString: Negative finish, middle" => [new HString("foobar"), new HString("ob"), 2, -2],
+            "ASCII HString: Negative start & finish, middle" => [new HString("foobar"), new HString("ob"), -4, -2],
+            "ASCII HString: normal middle" => [new HString("foobar"), new HString("ob"), 2, 2],
+            "ASCII HString: null finish" => [new HString("foobar"), new HString("obar"), 2, null],
+            "ASCII HString: overflow finish" => [new HString("foobar"), new HString("obar"), 2, 2000],
+            "UTF-8 HString: Negative finish, middle" => [new HString("ɹɐqooɟ"), new HString("qo"), 2, -2],
+            "UTF-8 HString: Negative start & finish, middle" => [new HString("ɹɐqooɟ"), new HString("qo"), -4, -2],
+            "UTF-8 HString: normal middle" => [new HString("ɹɐqooɟ"), new HString("qo"), 2, 2],
+            "UTF-8 HString: null finish" => [new HString("ɹɐqooɟ"), new HString("qooɟ"), 2, null],
+            "UTF-8 HString: overflow finish" => [new HString("ɹɐqooɟ"), new HString("qooɟ"), 2, 2000],
         ];
     }
 
     /**
      * @dataProvider badSlicingProvider()
      *
-     * @param $start
-     * @param $length
+     * @param HString $target
+     * @param integer $start
+     * @param integer $length
      * @param $exceptionMsg
      */
-    public function testBadSlicing($start, $length, $exceptionMsg)
+    public function testBadSlicing(HString $target, $start, $length, $exceptionMsg)
     {
         $this->setExpectedException("InvalidArgumentException", $exceptionMsg);
 
-        $this->aString->slice($start, $length);
+        $target->slice($start, $length);
     }
 
     public function badSlicingProvider()
     {
         return [
-            "No start or length of slice" => [null, null, "Slice parameter 1, \$start, must be an integer"],
-            "Non-integer start of slice" => ["cat", 4, "Slice parameter 1, \$start, must be an integer"],
-            "Non-integer length of slice" => ["1", "dog", "Slice parameter 2, \$length, must be null or an integer"],
+            "ASCII HString: No start or length of slice" =>
+                [new HString("foobar"), null, null, "Slice parameter 1, \$start, must be an integer"],
+            "ASCII HString: Non-integer start of slice" =>
+                [new HString("foobar"), "cat", 4, "Slice parameter 1, \$start, must be an integer"],
+            "ASCII HString: Non-integer length of slice" =>
+                [new HString("foobar"), "1", "dog", "Slice parameter 2, \$length, must be null or an integer"],
+            "UTF-8 HString: No start or length of slice" =>
+                [new HString("ɹɐqooɟ"), null, null, "Slice parameter 1, \$start, must be an integer"],
+            "UTF-8 HString: Non-integer start of slice" =>
+                [new HString("ɹɐqooɟ"), "cat", 4, "Slice parameter 1, \$start, must be an integer"],
+            "UTF-8 HString: Non-integer length of slice" =>
+                [new HString("ɹɐqooɟ"), "1", "dog", "Slice parameter 2, \$length, must be null or an integer"],
         ];
     }
 }

--- a/tests/Converter/StringToArrayTest.php
+++ b/tests/Converter/StringToArrayTest.php
@@ -34,6 +34,8 @@ class StringToArrayTest extends \PHPUnit_Framework_TestCase
     {
         $jabberwocky = "'Twas brillig and the slithy toves";
         $jabberwockyColon = "'Twas:brillig:and:the:slithy:toves";
+        $jabberUTF8 = "sǝʌoʇ ʎɥʇᴉls ǝɥʇ puɐ ƃᴉllᴉɹq sɐʍ┴,";
+        $jabberUTF8_short = "ƃᴉllᴉɹq sɐʍ┴,";
 
         return [
             "Empty String" => [new HString(), null, null, new HArray()],
@@ -47,11 +49,14 @@ class StringToArrayTest extends \PHPUnit_Framework_TestCase
             "String of integers with HString space delims" => [new HString("1 2 3 4 5"), new HString(" "), null, new HArray([1, 2, 3, 4, 5])],
             "String of integers with HString comma delims" => [new HString("1, 2, 3, 4, 5"), new HString(","), null, new HArray([1, 2, 3, 4, 5])],
             "String of words with null delims" => [new HString($jabberwocky), null, null, new HArray(["'", "T", "w", "a", "s", " ", "b", "r", "i", "l", "l", "i", "g", " ", "a", "n", "d", " ", "t", "h", "e", " ", "s", "l", "i", "t", "h", "y", " ", "t", "o", "v", "e", "s"])],
+            "String of UTF-8 words with null delims" => [new HString($jabberUTF8_short), null, null, new HArray(["ƃ", "ᴉ", "l", "l", "ᴉ" ,"ɹ" ,"q" ," ", "s", "ɐ", "ʍ", "┴", ","])],
             "String of words with space delims" => [new HString($jabberwocky), " ", null, new HArray(["'Twas", "brillig", "and", "the", "slithy", "toves"])],
+            "String of UTF-8 words with space delims" => [new HString($jabberUTF8), " ", null, new HArray(["sǝʌoʇ", "ʎɥʇᴉls", "ǝɥʇ", "puɐ", "ƃᴉllᴉɹq", "sɐʍ┴,"])],
             "String of words with colon delims" => [new HString($jabberwockyColon), ":", null, new HArray(["'Twas", "brillig", "and", "the", "slithy", "toves"])],
             "String of integers with space delims & limit" => [new HString("1 2 3 4 5"), " ", 3, new HArray([1, 2, "3 4 5"])],
             "String of integers with comma delims & limit" => [new HString("1, 2, 3, 4, 5"), ", ", 3, new HArray([1, 2, "3, 4, 5"])],
             "String of words with space delims & limit" => [new HString($jabberwocky), " ", 3, new HArray(["'Twas", "brillig", "and the slithy toves"])],
+            "String of UTF-8 words with space delims & limit" => [new HString($jabberUTF8), " ", 3, new HArray(["sǝʌoʇ", "ʎɥʇᴉls", "ǝɥʇ puɐ ƃᴉllᴉɹq sɐʍ┴,"])],
             "String of words with colon delims & limit" => [new HString($jabberwockyColon), ":", 3, new HArray(["'Twas", "brillig", "and:the:slithy:toves"])],
         ];
     }

--- a/tests/Functional/HArrayReduceTest.php
+++ b/tests/Functional/HArrayReduceTest.php
@@ -26,7 +26,7 @@ class HArrayReduceTest extends \PHPUnit_Framework_TestCase
     public function testArrayReduce(HArray $testArr, $expected)
     {
         $sum = function ($carry, $item) {
-            $carry += $item;
+            $carry += (int) $item;
             return $carry;
         };
 

--- a/tests/Functional/HStringFilterTest.php
+++ b/tests/Functional/HStringFilterTest.php
@@ -5,12 +5,15 @@ use Haystack\HString;
 
 class HStringFilterTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var \Haystack\HString */
+    /** @var HString */
     protected $aString;
+    /** @var HString */
+    protected $utf8String;
 
     protected function setUp()
     {
         $this->aString = new HString("foobar");
+        $this->utf8String = new HString("ɹɐqooɟ");
     }
 
     public function testStringDefaultFilter()
@@ -18,18 +21,25 @@ class HStringFilterTest extends \PHPUnit_Framework_TestCase
         $strangeString = $this->aString->insert(0, 3);
         $default = $strangeString->filter();
         $this->assertEquals("foobar", $default->toString(), "Filter with defaults");
+
+        $strangeString = $this->utf8String->insert(0, 3);
+        $default = $strangeString->filter();
+        $this->assertEquals("ɹɐqooɟ", $default->toString(), "Filter with defaults");
     }
 
     public function testStringValuesFilter()
     {
         $removeVowels = function ($letter) {
-            $vowels = new HString("aeiou");
+            $vowels = new HString("aeiouᴉǝɐ");
 
             return !$vowels->contains($letter);
         };
 
         $consonants = $this->aString->filter($removeVowels);
         $this->assertEquals("fbr", $consonants->toString(), "Filter by Value");
+
+        $consonants = $this->utf8String->filter($removeVowels);
+        $this->assertEquals("ɹqɟ", $consonants->toString(), "Filter by Value");
     }
 
     public function testStringKeyFilter()
@@ -41,7 +51,9 @@ class HStringFilterTest extends \PHPUnit_Framework_TestCase
         $flag = HString::USE_KEY;
 
         $even = $this->aString->filter($removeOdd, $flag);
+        $utf8Even = $this->utf8String->filter($removeOdd, $flag);
         $this->assertEquals("obr", $even->toString(), "Filter by Key");
+        $this->assertEquals("ɐoɟ", $utf8Even->toString(), "Filter by Key");
 
         $even = $this->aString->filter(function ($key) {
             return $key % 2;
@@ -68,6 +80,8 @@ class HStringFilterTest extends \PHPUnit_Framework_TestCase
         $flag = HString::USE_BOTH;
         $funky = $this->aString->filter($thingBoth, $flag);
         $this->assertEquals("fobr", $funky->toString(), "Filter by both Value & Key");
+        $utf8Funky = $this->utf8String->filter($thingBoth, $flag);
+        $this->assertEquals("ɐoɟ", $utf8Funky->toString(), "Filter by both Value & Key");
     }
 
     public function testInvalidFilterFlag()

--- a/tests/Functional/HStringMapTest.php
+++ b/tests/Functional/HStringMapTest.php
@@ -17,11 +17,10 @@ class HStringMapTest extends \PHPUnit_Framework_TestCase
     public function testStringMap()
     {
         $capitalize = function ($letter) {
-            return strtoupper($letter);
+            return mb_strtoupper($letter);
         };
 
         $newString = $this->aString->map($capitalize);
-
         $this->assertEquals("FOOBAR", $newString);
     }
 
@@ -36,7 +35,6 @@ class HStringMapTest extends \PHPUnit_Framework_TestCase
         };
 
         $newString = $this->aString->map($rot13);
-
         $expected = "sbbone";
         $this->assertEquals($expected, $newString);
     }

--- a/tests/Functional/HStringReduceTest.php
+++ b/tests/Functional/HStringReduceTest.php
@@ -17,7 +17,7 @@ class HStringReduceTest extends \PHPUnit_Framework_TestCase
     public function testReduce()
     {
         $fn = function ($carry, $item) {
-            $value = (ord(strtolower($item)) - 64);
+            $value = (ord(mb_strtolower($item)) - 64);
             return $carry + $value;
         };
 

--- a/tests/Functional/HStringWalkTest.php
+++ b/tests/Functional/HStringWalkTest.php
@@ -15,11 +15,9 @@ class HStringWalkTest extends \PHPUnit_Framework_TestCase
 
     public function testStringWalk()
     {
-        $capitalize = function ($letter, $key) {
+        $this->aString->walk(function ($letter, $key) {
             return $this->aString[$key] = strtoupper($letter);
-        };
-
-        $this->aString->walk($capitalize);
+        });
 
         $this->assertEquals("FOOBAR", $this->aString->toString());
     }

--- a/tests/HArrayTest.php
+++ b/tests/HArrayTest.php
@@ -10,11 +10,14 @@ class HArrayTest extends \PHPUnit_Framework_TestCase
     private $arrList;
     /** @var HArray */
     private $arrDict;
+    /** @var HArray */
+    private $arrUtf8Dict;
 
     protected function setUp()
     {
         $this->arrList = new HArray(["apple", "bobble", "cobble", "dobble"]);
         $this->arrDict = new HArray(["a" => "apple", "b" => "bobble", "c" => "cobble", "d" => "dobble"]);
+        $this->arrUtf8Dict = new HArray(["ɐ" => "ǝlddɐ", "q" => "ǝlqqoq", "ɔ" => "ǝlqqoɔ", "p" => "ǝlqqop"]);
     }
 
     public function testCreateEmptyArray()
@@ -58,12 +61,14 @@ class HArrayTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals("bobble", $this->arrList[1]);
         $this->assertEquals("bobble", $this->arrDict["b"]);
+        $this->assertEquals("ǝlqqoq", $this->arrUtf8Dict["q"]);
     }
 
     public function testArrayHead()
     {
         $this->assertEquals(new HArray(["apple"]), $this->arrList->head());
         $this->assertEquals(new HArray(["a" => "apple"]), $this->arrDict->head());
+        $this->assertEquals(new HArray(["ɐ" => "ǝlddɐ"]), $this->arrUtf8Dict->head());
     }
 
     public function testArrayTail()


### PR DESCRIPTION
I have been wanting HString to be UTF-8 aware for a long time. This PR takes care of that, I believe.

Some of the standard string functions in PHP have been ported to UTF-8, and those are the `mb_*` functions. I have used them where needed and have polyfilled where an appropriate `mb_*` is not available yet.

The `mb_*` functions fail big time in PHP 5.5. Rather than make them work in PHP 5.5, I'd like to bump up the minor version of current-master to v1.1.0 and that will be the last feature-release that is ready for PHP 5.5. Then I'll remove PHP 5.5 as a supported version for v2.0, which this will be the first new feature available.